### PR TITLE
Add Bats test for tmux setup

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Tests
+
+This directory contains Bats tests for the repository.
+
+Run the test suite from this directory with:
+
+```bash
+bats .
+```
+
+Make sure `bats` is installed and available in your `PATH`.

--- a/tests/tmux_setup.bats
+++ b/tests/tmux_setup.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+setup() {
+    TMPPATH="$(mktemp -d)"
+    OLD_PATH="$PATH"
+    PATH="$TMPPATH"
+}
+
+teardown() {
+    PATH="$OLD_PATH"
+    rm -rf "$TMPPATH"
+}
+
+@test "exits with status 1 when tmux isn't installed" {
+    cd "$BATS_TEST_DIRNAME/.."
+    run sh tmux/setup
+    [ "$status" -eq 1 ]
+    [ "$output" = "TMUX isn't installed. Skipping." ]
+}


### PR DESCRIPTION
## Summary
- add basic Bats test ensuring the tmux setup script skips if tmux is missing
- document running the Bats test suite

## Testing
- `bats tests/tmux_setup.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d196502dc83268e6276539d423a98