### PR TITLE
Fix misleading mkdir comment

### DIFF
--- a/install/alacritty
+++ b/install/alacritty
@@ -21,7 +21,8 @@ cd $dir/alacritty
 
 cargo build --release --no-default-features --features=wayland
 
-# mkdir -p is not POSIX compliant
+# The -p option of mkdir is POSIX compliant; these checks avoid creating
+# directories unnecessarily.
 [ ! -d ~/.local ] && mkdir ~/.local
 [ ! -d ~/.local/bin ] && mkdir ~/.local/bin
 


### PR DESCRIPTION
## Summary
- clarify that `mkdir -p` is POSIX compliant in the alacritty installer

## Testing
- `grep -n "mkdir" -n install/alacritty`


------
https://chatgpt.com/codex/tasks/task_e_684d1961340c8326a722dc34b59bf370