### PR TITLE
Fix vi alias check in bash

### DIFF
--- a/stow/bash/.bash_aliases
+++ b/stow/bash/.bash_aliases
@@ -37,7 +37,7 @@ alias c='printf "\e[H\e[2J"'
 alias more="less"
 alias ssh="TERM=xterm-256color ssh"
 
-_have vim && alias vi=vim
+command -v vim >/dev/null && alias vi=vim
 
 # ssh tunnel
 # alias <alias_name>="ssh -fnL <local_listen_port>:<localhost_or_remoteIP>:{remote_listen_port} -o ServerAliveInterval=30 <jump_proxy> -N"


### PR DESCRIPTION
## Summary
- ensure `vi` alias uses a POSIX-compatible command check

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d96a3270c832691f779c689543d4d