### PR TITLE
Add shell test for script syntax

### DIFF
--- a/tests/test_syntax.sh
+++ b/tests/test_syntax.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root relative to this script
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+bash -n "$ROOT_DIR/bootstrap/setup.sh"
+bash -n "$ROOT_DIR/bootstrap/install_devtools.sh"
+
+echo "Syntax check passed."


### PR DESCRIPTION
## Summary
- add `tests` directory with `test_syntax.sh` script
- run `bash -n` on bootstrap scripts

## Testing
- `./tests/test_syntax.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d96f4663c8326b97c8454cfe4d77c