### PR TITLE
Fix DOTFILES_DIR path

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-DOTFILES_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DOTFILES_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 STOW_PACKAGES=(alacritty bash tmux zsh)
 
 function install_stow_packages() {


### PR DESCRIPTION
## Summary
- adjust setup.sh to locate repository root and enable strict mode

## Testing
- `bash tests/test_syntax.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d99f9d15c8326912c2d2b458606a5